### PR TITLE
Use interpolationSymbols

### DIFF
--- a/ui-router-styles.js
+++ b/ui-router-styles.js
@@ -8,12 +8,14 @@
 
 angular
   .module('uiRouterStyles', ['ui.router'])
-  .directive('head', ['$rootScope', '$compile', '$state',
-    function($rootScope, $compile, $state) {
+  .directive('head', ['$rootScope', '$compile', '$state', '$interpolate',
+    function($rootScope, $compile, $state, $interpolate) {
       return {
         restrict: 'E',
         link: function(scope, elem){
-          var html = '<link rel="stylesheet" ng-repeat="(k, css) in routeStyles track by k" ng-href="{{css}}" >';
+          var start = $interpolate.startSymbol(),
+              end = $interpolate.endSymbol();
+          var html = '<link rel="stylesheet" ng-repeat="(k, css) in routeStyles track by k" ng-href="' + start + 'css' + end + '" >';
           elem.append($compile(html)(scope));
 
           // Get the parent state


### PR DESCRIPTION
Hi! Your module works great and is just what I was looking for, so thank you. 

This branch has a small change, but one that I ended up needing because I had overwritten angular's default interpolation symbols from `{{` to `{[`. I noticed that when the html for the `<link>` is generated the symbols were hardcoded so I injected `$interpolate` and used that to get the symbols from the app. That way it should handle things whether or not the symbols were changed.
