### PR TITLE
Changed listener to  in order to allow redirects in other listeners.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ This directive does the following things:
 
 * It compiles (using `$compile`) an html string that creates a set of <link /> tags for every item in the `data.css` state property using `ng-repeat` and `ng-href`.
 * It appends that compiled set of `<link />` elements to the `<head>` tag.
-* It then uses the `$rootScope` to listen for `'$stateChangeStart'` events. For every `'$stateChangeStart'` event, it cleans all css appended before and adds the new css file(s) to the `<head>` tag if there are any.
+* It then uses the `$rootScope` to listen for `'$stateChangeSuccess'` events. For every `'$stateChangeSuccess'` event, it cleans all css appended before and adds the new css file(s) to the `<head>` tag if there are any.

--- a/ui-router-styles.js
+++ b/ui-router-styles.js
@@ -27,7 +27,7 @@ angular
           };
 
           scope.routeStyles = [];
-          $rootScope.$on('$stateChangeStart', function (evt, toState) {
+          $rootScope.$on('$stateChangeSuccess', function (evt, toState) {
             // From current state to the root
             scope.routeStyles = [];
             for(var state = toState; state && state.name !== ''; state=$$parentState(state)) {


### PR DESCRIPTION
I ran into a problem where angular-ui-router-styles was not applying a style on a particular transition that I had.

A simplified version of the problem is:

app.js:
```javascript
$rootScope.$on('$stateChangeStart', function (evt, to, params) {
  if(to.name === 'levelA'){
     $state.go('levelA.levelB');
  }
});
```

When $state.go is called in the $stateChangeStart, ui-router did this weird reverse stack popping, which resulted in ui-router-styles removing the styles for `levelA.levelB`.

```
($stateChange listeners)
app.js: levelA
app.js: levelA.levelB
styles: levelA.levelB
styles: levelA
```

After changing the ui-router-styles.js handler to listen for `$stateChangeSuccess`, I get the following order:
```
app.js: levelA
app.js: levelA.levelB
styles: levelA.levelB
```